### PR TITLE
Fix namespace error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ return [
 		'log' => [
 			'targets' => [
 				[
-					'class' => 'pahanini\yii2-consolelog\ConsoleTarget',
+					'class' => 'pahanini\log\ConsoleTarget',
 					'levels' => ['error', 'warning', 'trace'],
 				]
 			],

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Usage
 -----
 
 
-```
+```php
 return [
 	'id' => 'app-console',
 	'bootstrap' => ['log'],


### PR DESCRIPTION
change incorrect namespace `pahanini\yii2-consolelog\ConsoleTarget` to `pahanini\log\ConsoleTarget`.
