### PR TITLE
Add support for microtime

### DIFF
--- a/ConsoleTarget.php
+++ b/ConsoleTarget.php
@@ -92,7 +92,9 @@ class ConsoleTarget extends Target
 
         //Add date to log
         if (true == $this->displayDate) {
-            $label.= '['.date($this->dateFormat, $message[3]).']';
+            $dt = \DateTime::createFromFormat('U.u', $message[3]);
+            $timestamp = $dt->format($this->dateFormat);
+            $label .= "[$timestamp]";
         }
 
         //Add category to label


### PR DESCRIPTION
This change adds support for microtime. Consider the following configuration (especially the `dateFormat` that includes microseconds):

```php
[
    'class' => 'pahanini\log\ConsoleTarget',
    'levels' => ['error', 'warning', 'trace'],
    'displayDate' => true,
    'dateFormat' => 'Y-m-d H:i:s.u',
    'microtime' => true,
],
```